### PR TITLE
fix: a socket may be unregistered when not registered

### DIFF
--- a/pyxmpp2/mainloop/poll.py
+++ b/pyxmpp2/mainloop/poll.py
@@ -63,7 +63,12 @@ class PollMainLoop(MainLoopBase):
         fileno = handler.fileno()
         if old_fileno is not None and fileno != old_fileno:
             del self._handlers[old_fileno]
-            self.poll.unregister(old_fileno)
+            try:
+                self.poll.unregister(old_fileno)
+            except KeyError:
+                # The socket has changed, but the old one isn't registered,
+                # e.g. ``prepare`` wants to connect again
+                pass
         if not prepared:
             self._unprepared_handlers[handler] = fileno
         if not fileno:


### PR DESCRIPTION
If a connection failed (e.g. network unreachable because no IPv6 access
available), the socket will change, but not the handler.

This should fix issue #68.
