### PR TITLE
error when connecting, just try next address

### DIFF
--- a/pyxmpp2/transport.py
+++ b/pyxmpp2/transport.py
@@ -762,6 +762,11 @@ class TCPTransport(XMPPTransport, IOHandler):
         Handle the 'channel hungup' state. The handler should not be writable
         after this.
         """
+        with self.lock:
+            if self._state == 'connecting' and self._dst_addrs:
+                self._hup = False
+                self._set_state("connect")
+                return
         self._hup = True
 
     def handle_err(self):


### PR DESCRIPTION
This can happen when DNS returns multiple IPs (e.g. IPv6 and IPv4 ones),
and connecting with the first one fails (e.g. server isn't listen on IPv6).

I've tested this on localhost with prosody listens only on IPv4.
