### PR TITLE
setup: use distribute only if installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,13 @@
 import os.path
 import sys
 
-from distribute_setup import use_setuptools
-use_setuptools("0.6.19")
-    
+try:
+    # use setuptools 0.6.19 if distribute is installed
+    from distribute_setup import use_setuptools
+    use_setuptools("0.6.19")
+except ImportError:
+    pass
+
 from setuptools import setup
 
 version = "2.0alpha2-git"


### PR DESCRIPTION
I'm running Ubuntu 12.04.3 LTS and distribute==0.7.3 and couldn't install pyxmpp2.

I could not import distribute_setup.

This try-except fixed it
