### PR TITLE
docs: Fix a few typos

### DIFF
--- a/pyxmpp2/binding.py
+++ b/pyxmpp2/binding.py
@@ -108,7 +108,7 @@ class ResourceBindingHandler(StreamFeatureHandler, XMPPFeatureHandler):
         """Add resource binding feature to the <features/> element of the
         stream.
 
-        [receving entity only]
+        [receiving entity only]
 
         :returns: update <features/> element.
         """

--- a/pyxmpp2/cache.py
+++ b/pyxmpp2/cache.py
@@ -54,7 +54,7 @@ class CacheItem(object):
         - `freshness_time`: time when the object stops being fresh.
         - `expire_time`: time when the object expires.
         - `purge_time`: time when the object should be purged. When 0 then
-          item will never be automaticaly purged.
+          item will never be automatically purged.
         - `_lock`: lock for thread safety.
     :Types:
         - `value`: `instance`
@@ -78,7 +78,7 @@ class CacheItem(object):
             - `freshness_period`: time interval after which the object stops being fresh.
             - `expiration_period`: time interval after which the object expires.
             - `purge_period`: time interval after which the object should be purged. When 0 then
-              item will never be automaticaly purged.
+              item will never be automatically purged.
             - `state`: initial state.
         :Types:
             - `address`: any hashable
@@ -148,7 +148,7 @@ class CacheFetcher:
     An instance of a fetcher class is created for each object requested and
     not found in the cache, then `fetch` method is called to initialize
     the asynchronous retrieval process. Fetcher object's `got_it` method
-    should be called on a successfull retrieval and `error` otherwise.
+    should be called on a successful retrieval and `error` otherwise.
     `timeout` will be called when the request timeouts.
 
     :Ivariables:
@@ -226,7 +226,7 @@ class CacheFetcher:
         raise RuntimeError("Pure virtual method called")
 
     def got_it(self, value, state = "new"):
-        """Handle a successfull retrieval and call apriopriate handler.
+        """Handle a successful retrieval and call apriopriate handler.
 
         Should be called when retrieval succeeds.
 
@@ -376,7 +376,7 @@ class Cache:
             purge_period = None):
         """Request an object with given address and state not worse than
         `state`. The object will be taken from cache if available, and
-        created/fetched otherwise. The request is asynchronous -- this metod
+        created/fetched otherwise. The request is asynchronous -- this method
         doesn't return the object directly, but the `object_handler` is called
         as soon as the object is available (this may be before `request_object`
         returns and may happen in other thread). On error the `error_handler`
@@ -411,7 +411,7 @@ class Cache:
             - `expiration_period`: time interval after which the item created
               should become 'stale'.
             - `purge_period`: time interval after which the item created
-              shuld be removed from the cache.
+              should be removed from the cache.
         :Types:
             - `address`: any hashable
             - `state`: "new", "fresh", "old" or "stale"
@@ -704,7 +704,7 @@ class CacheSuite:
         """Request an object of given class, with given address and state not
         worse than `state`. The object will be taken from cache if available,
         and created/fetched otherwise. The request is asynchronous -- this
-        metod doesn't return the object directly, but the `object_handler` is
+        method doesn't return the object directly, but the `object_handler` is
         called as soon as the object is available (this may be before
         `request_object` returns and may happen in other thread). On error the
         `error_handler` will be called, and on timeout -- the
@@ -740,7 +740,7 @@ class CacheSuite:
             - `expiration_period`: time interval after which the item created
               should become 'stale'.
             - `purge_period`: time interval after which the item created
-              shuld be removed from the cache.
+              should be removed from the cache.
         :Types:
             - `object_class`: `classobj`
             - `address`: any hashable

--- a/pyxmpp2/cert.py
+++ b/pyxmpp2/cert.py
@@ -107,7 +107,7 @@ class CertificateData(object):
         """Verify certificate for a server.
 
         :Parameters:
-            - `server_name`: name of the server presenting the cerificate
+            - `server_name`: name of the server presenting the certificate
             - `srv_type`: service type requested, as used in the SRV record
         :Types:
             - `server_name`: `unicode` or `JID`
@@ -178,7 +178,7 @@ class CertificateData(object):
         return False
 
     def verify_jid_against_srv_name(self, jid, srv_type):
-        """Check if the cerificate is valid for given domain-only JID
+        """Check if the certificate is valid for given domain-only JID
         and a service type.
 
         :Parameters:

--- a/pyxmpp2/ext/dataforms.py
+++ b/pyxmpp2/ext/dataforms.py
@@ -599,7 +599,7 @@ class Form(StanzaPayloadObject):
     def make_submit(self, keep_types = False):
         """Make a "submit" form using data in `self`.
 
-        Remove uneeded information from the form. The information removed
+        Remove unneeded information from the form. The information removed
         includes: title, instructions, field labels, fixed fields etc.
 
         :raise ValueError: when any required field has no value.

--- a/pyxmpp2/ext/legacyauth.py
+++ b/pyxmpp2/ext/legacyauth.py
@@ -100,7 +100,7 @@ class LegacyClientStream(ClientStream):
         ClientStream._post_connect(self)
 
     def _post_auth(self):
-        """Unregister legacy authentication handlers after successfull
+        """Unregister legacy authentication handlers after successful
         authentication."""
         ClientStream._post_auth(self)
         if not self.initiator:

--- a/pyxmpp2/ext/muc/muc.py
+++ b/pyxmpp2/ext/muc/muc.py
@@ -86,7 +86,7 @@ class MucRoomHandler:
         """
         Called when a requested configuration form is received.
 
-        The form, after filling-in shoul be passed to `self.room_state.configure_room`.
+        The form, after filling-in should be passed to `self.room_state.configure_room`.
 
         :Parameters:
             - `form`: the configuration form.
@@ -98,7 +98,7 @@ class MucRoomHandler:
 
     def room_configured(self):
         """
-        Called after a successfull room configuration.
+        Called after a successful room configuration.
         """
         pass
 
@@ -759,7 +759,7 @@ class MucRoomState:
 
         :Parameters:
             - `form`: the configuration parameters. Should be a 'submit' form made by filling-in
-              the configuration form retireved using `self.request_configuration_form` or
+              the configuration form retrieved using `self.request_configuration_form` or
               a 'cancel' form.
         :Types:
             - `form`: `Form`

--- a/pyxmpp2/ext/muc/muccore.py
+++ b/pyxmpp2/ext/muc/muccore.py
@@ -282,7 +282,7 @@ class MucItem(MucItemBase):
         - `role`: role of the user.
         - `jid`: JID of the user.
         - `nick`: nickname of the user.
-        - `actor`: actor modyfying the user data.
+        - `actor`: actor modifying the user data.
         - `reason`: reason of change of the user data.
     :Types:
         - `affiliation`: `str`
@@ -302,7 +302,7 @@ class MucItem(MucItemBase):
             - `role`: role of the user.
             - `jid`: JID of the user.
             - `nick`: nickname of the user.
-            - `actor`: actor modyfying the user data.
+            - `actor`: actor modifying the user data.
             - `reason`: reason of change of the user data.
         :Types:
             - `xmlnode_or_affiliation`: `libxml2.xmlNode` or `str`
@@ -327,7 +327,7 @@ class MucItem(MucItemBase):
             - `role`: role of the user.
             - `jid`: JID of the user.
             - `nick`: nickname of the user.
-            - `actor`: actor modyfying the user data.
+            - `actor`: actor modifying the user data.
             - `reason`: reason of change of the user data.
         :Types:
             - `affiliation`: `str`
@@ -418,7 +418,7 @@ class MucStatus(MucItemBase):
     MUC <item/> element - describes special meaning of a stanza
 
     :Ivariables:
-        - `code`: staus code, as defined in JEP 45
+        - `code`: status code, as defined in JEP 45
     :Types:
         - `code`: `int`
     """
@@ -677,7 +677,7 @@ class MucPresence(Presence,MucStanzaExt):
             - `to_jid`: recipient JID.
             - `stanza_type`: staza type: one of: None, "available", "unavailable",
               "subscribe", "subscribed", "unsubscribe", "unsubscribed" or
-              "error". "available" is automaticaly changed to_jid None.
+              "error". "available" is automatically changed to_jid None.
             - `stanza_id`: stanza id -- value of stanza's "id" attribute
             - `show`: "show" field of presence stanza. One of: None, "away",
               "xa", "dnd", "chat".

--- a/pyxmpp2/ext/register.py
+++ b/pyxmpp2/ext/register.py
@@ -204,7 +204,7 @@ class Register(StanzaPayloadObject):
 
         :Parameters:
             - `form_type`: If "form", then a form to fill-in should be
-              returned. If "sumbit", then a form with submitted data.
+              returned. If "submit", then a form with submitted data.
         :Types:
             - `form_type`: `unicode`
 

--- a/pyxmpp2/interfaces.py
+++ b/pyxmpp2/interfaces.py
@@ -57,7 +57,7 @@ class Resolver:
 
         `callback` will be called with a properly sorted list of (hostname,
         port) pairs on success. The list will be empty on error and it will
-        contain only (".", 0) when the service is explicitely disabled.
+        contain only (".", 0) when the service is explicitly disabled.
 
         :Parameters:
             - `domain`: domain name to look up

--- a/pyxmpp2/jid.py
+++ b/pyxmpp2/jid.py
@@ -110,7 +110,7 @@ class JID(object):
               Unicode representation of the JID.
             - `domain`: domain part of the JID
             - `resource`: resource part of the JID
-            - `check`: if `False` then JID is not checked for specifiaction
+            - `check`: if `False` then JID is not checked for specification
               compliance.
         """
 

--- a/pyxmpp2/mainloop/interfaces.py
+++ b/pyxmpp2/mainloop/interfaces.py
@@ -136,7 +136,7 @@ class IOHandler:
     @abstractmethod
     def handle_hup(self):
         """
-        Handle the 'channel hungup' state. The handler should not be writtable
+        Handle the 'channel hungup' state. The handler should not be writable
         after this.
         """
         pass

--- a/pyxmpp2/presence.py
+++ b/pyxmpp2/presence.py
@@ -67,7 +67,7 @@ class Presence(Stanza):
             - `to_jid`: recipient JID.
             - `stanza_type`: staza type: one of: None, "available",
               "unavailable", "subscribe", "subscribed", "unsubscribe",
-              "unsubscribed" or "error". "available" is automaticaly changed to
+              "unsubscribed" or "error". "available" is automatically changed to
               None.
             - `stanza_id`: stanza id -- value of stanza's "id" attribute
             - `language`: default language for the stanza content

--- a/pyxmpp2/resolver.py
+++ b/pyxmpp2/resolver.py
@@ -216,7 +216,7 @@ class DumbBlockingResolver(Resolver):
 
     def resolve_srv(self, domain, service, protocol, callback):
         raise NotImplementedError("The DumbBlockingResolver cannot resolve"
-                " SRV records. DNSPython or target hostname explicitely set"
+                " SRV records. DNSPython or target hostname explicitly set"
                                                                 " required")
 
     def resolve_address(self, hostname, callback, allow_cname = True):
@@ -288,7 +288,7 @@ if HAVE_DNSPYTHON:
 
             `callback` will be called with a properly sorted list of (hostname,
             port) pairs on success. The list will be empty on error and it will
-            contain only (".", 0) when the service is explicitely disabled.
+            contain only (".", 0) when the service is explicitly disabled.
 
             :Parameters:
                 - `domain`: domain name to look up

--- a/pyxmpp2/roster.py
+++ b/pyxmpp2/roster.py
@@ -691,7 +691,7 @@ class RosterClient(XMPPFeatureHandler, EventHandler):
         """Save the roster to an XML file.
 
         Can be used to save the last know roster copy for faster loading
-        of a verisoned roster (if server supports that).
+        of a versioned roster (if server supports that).
 
         :Parameters:
             - `dest`: file name or a file object

--- a/pyxmpp2/settings.py
+++ b/pyxmpp2/settings.py
@@ -66,7 +66,7 @@ class XMPPSettings(MutableMapping):
     """Container for various parameters used all over PyXMPP.
 
     It can be used like a regular dictionary, but will provide reasonable
-    defaults for PyXMPP for parameters which are not explicitely set.
+    defaults for PyXMPP for parameters which are not explicitly set.
 
     All known PyXMPP settings are included in the :r:`settings list`.
 
@@ -75,7 +75,7 @@ class XMPPSettings(MutableMapping):
         - `_defaults_factories`: factory functions providing default values
           which cannot be hard-coded.
     :Ivariables:
-        - `_settings`: current values of the parameters explicitely set.
+        - `_settings`: current values of the parameters explicitly set.
     """
     _defs = {}
     def __init__(self, data = None):

--- a/pyxmpp2/streambase.py
+++ b/pyxmpp2/streambase.py
@@ -432,7 +432,7 @@ class StreamBase(XMLStreamHandler):
     def _make_stream_features(self):
         """Create the <features/> element for the stream.
 
-        [receving entity only]
+        [receiving entity only]
 
         :returns: new <features/> element
         :returntype: :etree:`ElementTree.Element`"""

--- a/pyxmpp2/streamsasl.py
+++ b/pyxmpp2/streamsasl.py
@@ -98,7 +98,7 @@ class StreamSASLHandler(StreamFeatureHandler):
     def make_stream_features(self, stream, features):
         """Add SASL features to the <features/> element of the stream.
 
-        [receving entity only]
+        [receiving entity only]
 
         :returns: update <features/> element."""
         mechs = self.settings['sasl_mechanisms']

--- a/pyxmpp2/streamtls.py
+++ b/pyxmpp2/streamtls.py
@@ -72,7 +72,7 @@ class StreamTLSHandler(StreamFeatureHandler, EventHandler):
     def make_stream_tls_features(self, stream, features):
         """Update the <features/> element with StartTLS feature.
 
-        [receving entity only]
+        [receiving entity only]
 
         :Parameters:
             - `features`: the <features/> element of the stream.

--- a/pyxmpp2/test/_util.py
+++ b/pyxmpp2/test/_util.py
@@ -29,7 +29,7 @@ socket.setdefaulttimeout(5)
 TIMEOUT = 60.0 # seconds
 
 class NetReaderWritter(object):
-    """Threaded network reader/writter.
+    """Threaded network reader/writer.
 
     :Ivariables:
         - `sock`: the socket
@@ -55,15 +55,15 @@ class NetReaderWritter(object):
         self.peer = None
 
     def start(self):
-        """Start the reader and writter threads."""
+        """Start the reader and writer threads."""
         reader_thread = threading.Thread(target = self.reader_run,
                                                             name = "Reader")
         reader_thread.daemon = True
-        writter_thread = threading.Thread(target = self.writter_run,
-                                                            name = "Writter")
-        writter_thread.daemon = True
+        writer_thread = threading.Thread(target = self.writer_run,
+                                                            name = "Writer")
+        writer_thread.daemon = True
         reader_thread.start()
-        writter_thread.start()
+        writer_thread.start()
 
     def _do_tls_handshake(self):
         """Do the TLS handshake. Called from the reader thread
@@ -107,8 +107,8 @@ class NetReaderWritter(object):
             self.extra_on_read = self._do_tls_handshake
             self.rdata = b""
 
-    def writter_run(self):
-        """The writter thread function."""
+    def writer_run(self):
+        """The writer thread function."""
         with self.write_cond:
             while self.sock is not None:
                 while self.ready and self.wdata and self.write_enabled:
@@ -422,7 +422,7 @@ class ReceiverSelectTestCase(NetworkTestCase):
 
     def start_transport(self, handlers):
         """Create a listening socket for the tested stream,
-        a transport a main loop and create a client connectiong to the
+        a transport a main loop and create a client connecting to the
         socket."""
         sock = self.make_listening_socket()
         self.addr = sock.getsockname()
@@ -489,7 +489,7 @@ class ReceiverThreadedTestMixIn(object):
 
     def start_transport(self, handlers):
         """Create a listening socket for the tested stream,
-        a transport a main loop and create a client connectiong to the
+        a transport a main loop and create a client connecting to the
         socket."""
         super(ReceiverThreadedTestMixIn, self).start_transport(handlers)
         self.loop.start()


### PR DESCRIPTION
There are small typos in:
- README.rst
- pyxmpp2/binding.py
- pyxmpp2/cache.py
- pyxmpp2/cert.py
- pyxmpp2/ext/dataforms.py
- pyxmpp2/ext/legacyauth.py
- pyxmpp2/ext/muc/muc.py
- pyxmpp2/ext/muc/muccore.py
- pyxmpp2/ext/register.py
- pyxmpp2/interfaces.py
- pyxmpp2/jid.py
- pyxmpp2/mainloop/interfaces.py
- pyxmpp2/presence.py
- pyxmpp2/resolver.py
- pyxmpp2/roster.py
- pyxmpp2/settings.py
- pyxmpp2/streambase.py
- pyxmpp2/streamsasl.py
- pyxmpp2/streamtls.py
- pyxmpp2/test/_util.py

Fixes:
- Should read `successful` rather than `successfull`.
- Should read `receiving` rather than `receving`.
- Should read `automatically` rather than `automaticaly`.
- Should read `writer` rather than `writter`.
- Should read `modifying` rather than `modyfying`.
- Should read `explicitly` rather than `explicitely`.
- Should read `certificate` rather than `cerificate`.
- Should read `should` rather than `shuld`.
- Should read `method` rather than `metod`.
- Should read `connecting` rather than `connectiong`.
- Should read `writable` rather than `writtable`.
- Should read `versioned` rather than `verisoned`.
- Should read `unneeded` rather than `uneeded`.
- Should read `submit` rather than `sumbit`.
- Should read `status` rather than `staus`.
- Should read `specification` rather than `specifiaction`.
- Should read `should` rather than `shoul`.
- Should read `retrieved` rather than `retireved`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md